### PR TITLE
CLI: Improve execute + configure commands & Add -c flag in order to run a string sql statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8.git
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/cli/commands/configure.py
+++ b/cli/commands/configure.py
@@ -1,20 +1,45 @@
+from typing import Optional
+
 import click
-from yarl import URL
 
 from cli.commands.context import CliContext
-from cli.config import ConfigurationManager, Profile
-from cli.formatters import OutputFmt
+from cli.config import Profile
+from cli.errors import ConfigErr
+from cli.formatters import OutputFmt, get_output_format
+from cli.utils import parse_url
 
 
 @click.command(help='Interactively configure CLI settings')
 @click.pass_obj
-def configure(ctx: CliContext) -> None:
+@click.option('-t', '--token', default=None,
+              help='Token to use.')
+@click.option('-u', '--api-url', default=None,
+              help='URL of Upsolver\'s API.')
+@click.option('-o', '--output-format', default=None,
+              help='The format that the results will be returned in. '
+                   'Supported formats: Json, Csv, Tsv, Plain. Default is Json.')
+def configure(ctx: CliContext,
+              token: Optional[str],
+              api_url: Optional[str],
+              output_format: Optional[str]) -> None:
     profile = ctx.confman.conf.active_profile
-    ctx.confman.update_profile(Profile(
-        name=profile.name,
-        token=click.prompt('API Access Token', profile.token),
-        base_url=URL(click.prompt('API Endpoint',
-                                  profile.base_url if profile.base_url is not None
-                                  else ConfigurationManager.CLI_DEFAULT_BASE_URL)),
-        output=OutputFmt(click.prompt('Default Output Format', profile.output.value))
-    ))
+
+    token = token or profile.token
+    if token is None:
+        raise ConfigErr("Can't create a new profile without a token, pleas provide it by using -t flag.")
+
+    base_url = parse_url(api_url) if api_url else profile.base_url
+    if base_url is None:
+        raise ConfigErr("Can't create a new profile without a api-url, pleas provide it by using -u flag.")
+    assert base_url.is_absolute()
+
+    output = get_output_format(output_format) or profile.output or OutputFmt.JSON
+
+    ctx.confman.update_profile(
+        Profile(
+            name=profile.name,
+            token=token,
+            base_url=base_url,
+            output=output
+        )
+    )

--- a/cli/commands/context.py
+++ b/cli/commands/context.py
@@ -86,13 +86,12 @@ class CliContext(object):
 
         return RestAuthApi(auth_base_url)
 
-    def upsolver_api(self) -> UpsolverApi:
-        auth_settings: Optional[ProfileAuthSettings] = \
-            get_auth_settings(self.confman.conf.active_profile)
+    def upsolver_api(self, auth_settings: Optional[ProfileAuthSettings] = None) -> UpsolverApi:
+        auth_settings = auth_settings or get_auth_settings(self.confman.conf.active_profile)
 
         if auth_settings is None:
-            raise ConfigErr('Could not find authentication settings, please use the '
-                            '`login` sub-command to generate them.')
+            raise ConfigErr('Could not find authentication settings, '
+                            'please use the `configure` sub-command to create a profile.')
 
         return build_upsolver_api(
             requester=Requester(

--- a/cli/commands/context.py
+++ b/cli/commands/context.py
@@ -29,7 +29,7 @@ def init_logging(conf: Config) -> None:
     log = get_logger()
 
     lvl = (
-        LogLvl.DEBUG if conf.debug
+        LogLvl.DEBUG if conf.verbose
         else (conf.options.log_level if conf.options is not None else LogLvl.CRITICAL)
     ).to_logging()
 
@@ -45,8 +45,8 @@ def init_logging(conf: Config) -> None:
             maxBytes=2 * (2 ** 20),
         ))
 
-    # if debug mode, also write to stderr
-    if conf.debug:
+    # if verbose mode, also write to stderr
+    if conf.verbose:
         log.setLevel(logging.DEBUG)
         handlers.append(logging.StreamHandler())
 

--- a/cli/commands/execute.py
+++ b/cli/commands/execute.py
@@ -7,7 +7,7 @@ from click import echo
 from cli.commands.context import CliContext
 from cli.config import ProfileAuthSettings
 from cli.errors import ConfigErr
-from cli.formatters import Formatter, OutputFmt
+from cli.formatters import Formatter, get_output_format
 from cli.utils import convert_time_str, parse_url
 
 
@@ -58,13 +58,8 @@ def execute(
     if len(expression) == 0:
         return
 
-    fmt: Optional[Formatter] = None
-    if output_format is not None:
-        try:
-            fmt = OutputFmt(output_format.lower()).get_formatter()
-        except ValueError:
-            raise ConfigErr("Output format {} is not supported. "
-                            "Supported formats: Json, Csv, Tsv, Plain.".format(output_format))
+    output_format = get_output_format(output_format)
+    fmt: Optional[Formatter] = output_format.get_formatter() if output_format else None
 
     if token and api_url:
         api_url = parse_url(api_url)

--- a/cli/commands/execute.py
+++ b/cli/commands/execute.py
@@ -21,7 +21,8 @@ from cli.utils import convert_time_str, parse_url
 @click.option('-c', '--command', is_flag=True, default=False,
               help='Execute a string sql statement.')
 @click.option('-o', '--output-format', default=None,
-              help='The format that the results will be returned in.')
+              help='The format that the results will be returned in. '
+                   'Supported formats: Json, Csv, Tsv, Plain. Default is Json.')
 @click.option('--timeout', 'timeout_sec', default='10s', callback=convert_time_str,
               help='Timeout setting for pending responses.')
 @click.option('-d', '--dry-run', is_flag=True, default=False,
@@ -62,7 +63,8 @@ def execute(
         try:
             fmt = OutputFmt(output_format.lower()).get_formatter()
         except ValueError:
-            pass
+            raise ConfigErr("Output format {} is not supported. "
+                            "Supported formats: Json, Csv, Tsv, Plain.".format(output_format))
 
     if token and api_url:
         api_url = parse_url(api_url)

--- a/cli/commands/execute.py
+++ b/cli/commands/execute.py
@@ -5,18 +5,24 @@ import click
 from click import echo
 
 from cli.commands.context import CliContext
+from cli.config import ProfileAuthSettings
+from cli.errors import ConfigErr
 from cli.formatters import Formatter, OutputFmt
-from cli.utils import convert_time_str
+from cli.utils import convert_time_str, parse_url
 
 
 @click.command()
 @click.pass_obj
 @click.argument('expression')
+@click.option('-t', '--token', default=None,
+              help='Token to use. Requires to provide api-url as well.')
+@click.option('-u', '--api-url', default=None,
+              help='URL of Upsolver\'s API. Requires to provide token as well.')
 @click.option('-c', '--command', is_flag=True, default=False,
               help='Execute a string sql statement.')
 @click.option('-o', '--output-format', default=None,
               help='The format that the results will be returned in.')
-@click.option('-t', '--timeout', 'timeout_sec', default='10s', callback=convert_time_str,
+@click.option('--timeout', 'timeout_sec', default='10s', callback=convert_time_str,
               help='Timeout setting for pending responses.')
 @click.option('-d', '--dry-run', is_flag=True, default=False,
               help='Validate expression is syntactically valid but don\'t run the command.')
@@ -25,6 +31,8 @@ from cli.utils import convert_time_str
 def execute(
         ctx: CliContext,
         expression: str,
+        token: Optional[str],
+        api_url: Optional[str],
         command: bool,
         output_format: Optional[str],
         timeout_sec: float,
@@ -56,7 +64,16 @@ def execute(
         except ValueError:
             pass
 
-    api = ctx.upsolver_api()
+    if token and api_url:
+        api_url = parse_url(api_url)
+        assert api_url.is_absolute()
+        api = ctx.upsolver_api(ProfileAuthSettings(token, api_url))
+    elif token or api_url:
+        raise ConfigErr("Please provide api-url with token or use the `configure` sub-command "
+                        "to create a proper profile and use it with -p flag.")
+    else:
+        api = ctx.upsolver_api()
+
     if dry_run:
         check_result = api.check_syntax(expression)
         if len(check_result) > 0:

--- a/cli/commands/execute.py
+++ b/cli/commands/execute.py
@@ -13,9 +13,9 @@ from cli.utils import convert_time_str
 @click.pass_obj
 @click.argument('expression')
 @click.option('-o', '--output-format', default=None,
-              help='The format that the results will be returned in')
+              help='The format that the results will be returned in.')
 @click.option('-t', '--timeout', 'timeout_sec', default='10s', callback=convert_time_str,
-              help='Timeout setting for pending responses')
+              help='Timeout setting for pending responses.')
 @click.option('-d', '--dry-run', is_flag=True, default=False,
               help='Validate expression is syntactically valid but don\'t run the command.')
 @click.option('-s', '--ignore-errors', is_flag=True, default=False,

--- a/cli/config.py
+++ b/cli/config.py
@@ -83,7 +83,7 @@ class Config(NamedTuple):
     active_profile: Profile
     profiles: list
     options: Optional[Options]
-    debug: bool  # user has used the --debug flag
+    verbose: bool  # user has used the --verbose flag
 
 
 def get_home_dir() -> Path:
@@ -117,7 +117,7 @@ class ConfigurationManager(object):
         return confparser
 
     @staticmethod
-    def _parse_conf_file(path: Path, profile: Optional[str], debug: bool) -> Config:
+    def _parse_conf_file(path: Path, profile: Optional[str], verbose: bool) -> Config:
         def get_log_file_path(parser: configparser.ConfigParser) -> Path:
             path_str = parser.get('options', 'log_file', fallback=None)
             if path_str is not None:
@@ -127,7 +127,7 @@ class ConfigurationManager(object):
 
         def get_log_lvl(parser: configparser.ConfigParser) -> LogLvl:
             lvl_str: str = \
-                'DEBUG' if debug else parser.get('options', 'log_level', fallback='')
+                'DEBUG' if verbose else parser.get('options', 'log_level', fallback='')
             if lvl_str != '':
                 return LogLvl[lvl_str]
             else:
@@ -173,12 +173,12 @@ class ConfigurationManager(object):
                 log_file=get_log_file_path(confparser),
                 log_level=get_log_lvl(confparser)
             ),
-            debug=debug
+            verbose=verbose
         )
 
-    def __init__(self, path: Path, profile: Optional[str] = None, debug: bool = False) -> None:
+    def __init__(self, path: Path, profile: Optional[str] = None, verbose: bool = False) -> None:
         self.conf_path = path
-        self.conf = self._parse_conf_file(self.conf_path, profile, debug)
+        self.conf = self._parse_conf_file(self.conf_path, profile, verbose)
 
     def get_formatter(self) -> Formatter:
         return self.conf.active_profile.output.get_formatter()

--- a/cli/formatters.py
+++ b/cli/formatters.py
@@ -123,3 +123,12 @@ def fmt_plain(x: Any) -> str:
         )
 
     return fmt_any(x, fmt_list)
+
+
+def get_output_format(output_format: Optional[str]):
+    if output_format is not None:
+        try:
+            return OutputFmt(output_format.lower())
+        except ValueError:
+            raise errors.ConfigErr("Output format {} is not supported. "
+                                   "Supported formats: Json, Csv, Tsv, Plain.".format(output_format))

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,14 +12,9 @@ from yarl import URL
 
 import cli as clipkg
 from cli import errors
-from cli.commands.catalogs import catalogs
-from cli.commands.clusters import clusters
 from cli.commands.configure import configure
 from cli.commands.context import CliContext
 from cli.commands.execute import execute
-from cli.commands.jobs import jobs
-from cli.commands.login import login
-from cli.commands.tables import tables
 from cli.config import ConfigurationManager
 
 
@@ -50,13 +45,13 @@ def cli(
     ctx.obj = CliContext(confman=ConfigurationManager(conf_path, profile, verbose))
 
 
-cli.add_command(login)
 cli.add_command(configure)
 cli.add_command(execute)
-cli.add_command(clusters)
-cli.add_command(catalogs)
-cli.add_command(tables)
-cli.add_command(jobs)
+# cli.add_command(login)
+# cli.add_command(clusters)
+# cli.add_command(catalogs)
+# cli.add_command(tables)
+# cli.add_command(jobs)
 
 
 def exit_with(code: errors.ExitCode, msg: str) -> None:

--- a/cli/main.py
+++ b/cli/main.py
@@ -29,7 +29,7 @@ from cli.config import ConfigurationManager
 @click.option('-p', '--profile', default=None,
               help='Commands will be executed using this profile\'s auth token.')
 @click.option('-c', '--config', default=None,
-              help='path and name of the upsql configuration file.')
+              help='Path and name of the upsql configuration file.')
 @click.option('-v', '--verbose', is_flag=True, default=False,
               help='Set verbose output.')
 def cli(

--- a/cli/main.py
+++ b/cli/main.py
@@ -30,13 +30,13 @@ from cli.config import ConfigurationManager
               help='Commands will be executed using this profile\'s auth token.')
 @click.option('-c', '--config', default=None,
               help='path and name of the upsql configuration file.')
-@click.option('--debug', is_flag=True, default=False,
-              help='Set logging level to DEBUG and log to stdout.')
+@click.option('-v', '--verbose', is_flag=True, default=False,
+              help='Set verbose output.')
 def cli(
     ctx: click.Context,
     profile: Optional[str],
     config: Optional[str],
-    debug: bool,
+    verbose: bool,
 ) -> None:
     """
     Upsolver CLI
@@ -47,7 +47,7 @@ def cli(
         else Path(os.path.expanduser(config))
     )
 
-    ctx.obj = CliContext(confman=ConfigurationManager(conf_path, profile, debug))
+    ctx.obj = CliContext(confman=ConfigurationManager(conf_path, profile, verbose))
 
 
 cli.add_command(login)
@@ -60,7 +60,7 @@ cli.add_command(jobs)
 
 
 def exit_with(code: errors.ExitCode, msg: str) -> None:
-    if '--debug' in sys.argv:
+    if '--verbose' in sys.argv:
         traceback.print_exc()
 
     echo(err=True, message=msg)

--- a/tests/test_confman.py
+++ b/tests/test_confman.py
@@ -56,7 +56,7 @@ def test_simple(tmp_path: Path):
         active_profile=default_profile,
         profiles=[default_profile],
         options=Options(ConfigurationManager.CLI_DEFAULT_LOG_PATH, LogLvl.CRITICAL),
-        debug=False,
+        verbose=False,
     )
 
 
@@ -75,7 +75,7 @@ def test_nonexistent_profile_is_ok(tmp_path: Path):
         active_profile=Profile(name='doesntexist', token=None, base_url=None),
         profiles=[default_profile],
         options=Options(ConfigurationManager.CLI_DEFAULT_LOG_PATH, LogLvl.CRITICAL),
-        debug=False,
+        verbose=False,
     )
 
 
@@ -89,7 +89,7 @@ def test_setting_option(tmp_path: Path):
         active_profile=default_profile,
         profiles=[default_profile],
         options=Options(ConfigurationManager.CLI_DEFAULT_LOG_PATH, LogLvl.INFO),
-        debug=False,
+        verbose=False,
     )
 
 
@@ -104,7 +104,7 @@ def test_active_profile(tmp_path: Path):
         active_profile=active_profile,
         profiles=[default_profile, active_profile],
         options=Options(ConfigurationManager.CLI_DEFAULT_LOG_PATH, LogLvl.CRITICAL),
-        debug=False,
+        verbose=False,
     )
 
 
@@ -119,7 +119,7 @@ def test_profile_update(tmp_path: Path):
         active_profile=active_profile,
         profiles=[default_profile, active_profile],
         options=Options(ConfigurationManager.CLI_DEFAULT_LOG_PATH, LogLvl.CRITICAL),
-        debug=False,
+        verbose=False,
     )
 
     new_active_profile = Profile(name='kool', token='stam2', base_url=URL('https://stam2'))
@@ -133,5 +133,5 @@ def test_option_log_file_path():
     pass
 
 
-def test_debug_flag():
+def test_verbose_flag():
     pass


### PR DESCRIPTION
1. Verbose instead of debug 
2. Run sql with -c/--command 
3. Remove all commands but execute and configure
4. Execute command: Added flags:  -t/--token <token> -u/--api-url <url> -o/--output-format <output_format>
5. Configure command: Added flags:  -t/--token <token> -u/--api-url <url> 

Fixes [US-3689](https://upsolver.atlassian.net/browse/US-3689)  + [US-2340](https://upsolver.atlassian.net/browse/US-2340) + [US-3230](https://upsolver.atlassian.net/browse/US-3230) +  [US-3741](https://upsolver.atlassian.net/browse/US-3741)